### PR TITLE
Update instructions for using scenario 3 for multiple properties

### DIFF
--- a/ga_customize.view.lkml
+++ b/ga_customize.view.lkml
@@ -41,7 +41,7 @@ view: ga_sessions {
   #   }
 
 
-  # SCENARIO 3: Multiple properties. The property will dynamically look at the selected dataset. If using this pattern, change the partition_date definition in the ga_block file  to type: date_time (no sql clause)
+  # SCENARIO 3: Multiple properties. The property will dynamically look at the selected dataset. If using this pattern, change the partition_date definition in the ga_block file from a `dimension:` to a `filter:` and comment out the `sql:` clause.
   # sql_table_name: (SELECT *,'Property1' AS Property FROM `dataset_number.ga_sessions_*` WHERE {% condition partition_date %} TIMESTAMP(PARSE_DATE('%Y%m%d', REGEXP_EXTRACT(_TABLE_SUFFIX,r'^\d\d\d\d\d\d\d\d'))) {% endcondition %}
   #  UNION ALL SELECT *,'Property2' AS Property FROM `dataset_number2.ga_sessions_*` WHERE {% condition partition_date %} TIMESTAMP(PARSE_DATE('%Y%m%d', REGEXP_EXTRACT(_TABLE_SUFFIX,r'^\d\d\d\d\d\d\d\d'))) {% endcondition %});;
 


### PR DESCRIPTION
I'm setting up the ga360 block with a bigquery connection and have run into a problem I'm not sure how to solve.
This is the error message I'm getting: Failed to retrieve data - Name partition_date not found inside ga_sessions at [9:24]
this is where partition_date shows up in the query: "WHERE 
	(((ga_sessions.partition_date) >= ((TIMESTAMP_ADD(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY), INTERVAL -7 DAY))) AND (ga_sessions.partition_date) < ((TIMESTAMP_ADD(TIMESTAMP_ADD(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY), INTERVAL -7 DAY), INTERVAL 7 DAY)))))"
I'm using scenario #3 to handle multiple properties. And commented out the sql clause for the partition_date field as instructed in the block comments.

Solution was to change from `dimension:` to `filter:` on the `partition_date` field so it's only included in the sql_table_name view condition for the FROM clause, but not be in the WHERE clause. I removed the note about changing the field `type:` because it's already that `type:`.